### PR TITLE
ReActivate Task

### DIFF
--- a/src/components/DialogForm.tsx
+++ b/src/components/DialogForm.tsx
@@ -25,8 +25,8 @@ export interface DialogFormProps extends DialogProps {
   deleteLabel?: string
   instructions?: string
   onClose: () => void
-  onSubmit: () => Promise<void>
-  onDelete?: () => Promise<void>
+  onSubmit: () => Promise<unknown>
+  onDelete?: () => Promise<unknown>
   disableSubmitBtn?: boolean
 }
 

--- a/src/components/TimerItem/TimerItem.tsx
+++ b/src/components/TimerItem/TimerItem.tsx
@@ -101,6 +101,14 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
     return task.user === currentUser._id && task.state === TaskState.Active
   }, [])
 
+  const isDeliveredTask = useCallback((task: Task): boolean => {
+    return task.state === TaskState.Delivered
+  }, [])
+
+  const isCancelledTask = useCallback((task: Task): boolean => {
+    return task.state === TaskState.Cancelled
+  }, [])
+
   const createTask = useCallback(
     (summary: string) => {
       if (!project) return
@@ -128,9 +136,7 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
           pullRequestLink: null
         })
         .then((task) => {
-          setSortedTaskOptions((tasks) =>
-            tasks ? [task, ...tasks] : []
-          )
+          setSortedTaskOptions((tasks) => (tasks ? [task, ...tasks] : []))
           updateTimer(timer._id, {task: task._id})
         })
         .catch(console.error)
@@ -226,7 +232,11 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
                 (option) => getOptionLabel(option) === inputValue
               )
 
-              if (inputValue !== "" && !isExistingTask) {
+              const isDeliveredTask = filtered.some(
+                (option) => getOptionLabel(option) === inputValue
+              )
+
+              if (inputValue !== "" && !isExistingTask && !isDeliveredTask) {
                 filtered.push(inputValue)
               }
 

--- a/src/components/TimerItem/TimerItem.tsx
+++ b/src/components/TimerItem/TimerItem.tsx
@@ -368,7 +368,7 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
         submitLabel="Reactivate"
         cancelLabel="No"
       >
-        this task is currently {""}
+        {task?.summary} is currently {""}
         {task?.state === TaskState.Delivered ? "delivered" : "cancelled"}, would
         you like to reactivate it?
       </DialogForm>

--- a/src/components/TimerItem/TimerItem.tsx
+++ b/src/components/TimerItem/TimerItem.tsx
@@ -127,14 +127,25 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
   }, [])
 
   const isOpenTask = useCallback((task: Task): boolean => {
-    return task.state !== TaskState.Delivered ?? TaskState.Cancelled
+    return (
+      task.state !== TaskState.Delivered && task.state !== TaskState.Cancelled
+    )
   }, [])
 
   const changeToActive = () =>
     session.task.modify(task?._id ?? "", {
-      state: {
-        Assign: TaskState.Active
-      }
+      Chain: [
+        {
+          state: {
+            Assign: TaskState.Active
+          }
+        },
+        {
+          user: {
+            Assign: currentUser._id
+          }
+        }
+      ]
     })
 
   const createTask = useCallback(
@@ -173,7 +184,14 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
     [project]
   )
 
-  console.log(text, task?.summary, task?.state, openModal)
+  console.log(
+    text,
+    task?.summary,
+    task?.state,
+    openModal,
+    isOpenTask,
+    task?.user
+  )
 
   return (
     <>
@@ -241,9 +259,11 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
               onChange={(e, value) => {
                 if (typeof value === "string") {
                   createTask(value)
-                } else if (
-                  value?.state === (TaskState.Delivered ?? TaskState.Cancelled)
-                ) {
+                } else if (value?.state === TaskState.Delivered) {
+                  updateTimer(timer._id, {task: value?._id})
+                  setText(value.summary)
+                  SetOpenModal(true)
+                } else if (value?.state === TaskState.Cancelled) {
                   updateTimer(timer._id, {task: value?._id})
                   setText(value.summary)
                   SetOpenModal(true)

--- a/src/components/TimerItem/TimerItem.tsx
+++ b/src/components/TimerItem/TimerItem.tsx
@@ -4,9 +4,7 @@ import {
   Autocomplete,
   Box,
   Button,
-  Dialog,
   IconButton,
-  Modal,
   Paper,
   Stack,
   TextField,
@@ -27,7 +25,6 @@ import {AuthContext, TimerContext} from "utils/context"
 import {ContentCollapsed} from "./ContentCollapsed"
 import HmsInputGroup from "./hmsInputGroup"
 import {useThrottle} from "@lightningkite/react-lightning-helpers"
-import {TaskModal} from "components/TaskModal"
 import DialogForm from "components/DialogForm"
 
 export interface TimerItemProps {
@@ -74,7 +71,7 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
       return
     }
     let promise: Promise<Array<Task>>
-    if (text === "" || task?.summary === text) {
+    if (text === "") {
       promise = session.task.query({
         limit: 1000,
         condition: {
@@ -249,7 +246,7 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
                 ) {
                   updateTimer(timer._id, {task: value?._id})
                   setText(value.summary)
-                  // SetOpenModal(true)
+                  SetOpenModal(true)
                 } else {
                   updateTimer(timer._id, {task: value?._id})
                   setText(value?.summary ?? "")
@@ -349,8 +346,12 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
         onSubmit={changeToActive}
         open={openModal}
         submitLabel="Reactivate"
-        cancelLabel="Close"
-      ></DialogForm>
+        cancelLabel="No"
+      >
+        this task is currently {""}
+        {task?.state === TaskState.Delivered ? "delivered" : "cancelled"}, would
+        you like to reactivate it?
+      </DialogForm>
     </>
   )
 }

--- a/src/components/TimerItem/TimerItem.tsx
+++ b/src/components/TimerItem/TimerItem.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   IconButton,
+  Link,
   Paper,
   Stack,
   TextField,
@@ -368,9 +369,12 @@ export const TimerItem: FC<TimerItemProps> = ({timer, projectOptions}) => {
         submitLabel="Reactivate"
         cancelLabel="No"
       >
-        {task?.summary} is currently {""}
-        {task?.state === TaskState.Delivered ? "delivered" : "cancelled"}, would
-        you like to reactivate it?
+        <Link href={`/projects/${project?._id}/tasks/${task?._id}`}>
+          {task?.summary}
+        </Link>
+        {" is currently "}
+        {task?.state === TaskState.Delivered ? "delivered" : "cancelled"}
+        {", would you like to reactivate it?"}
       </DialogForm>
     </>
   )

--- a/src/pages/ReportsPage/RevenueReport.tsx
+++ b/src/pages/ReportsPage/RevenueReport.tsx
@@ -230,7 +230,7 @@ export const RevenueReport: FC<ReportProps> = ({reportFilterValues}) => {
                           <ListItemText
                             primary={task.summary}
                             secondary={`${task.state} – ${totalHours.toFixed(
-                              1
+                              2
                             )} hours`}
                           />
                         </ListItem>
@@ -240,7 +240,7 @@ export const RevenueReport: FC<ReportProps> = ({reportFilterValues}) => {
                     <ListItem>
                       <ListItemText
                         primary="Project Management"
-                        secondary={`${orphanHours.toFixed(1)} hours`}
+                        secondary={`${orphanHours.toFixed(2)} hours`}
                       />
                     </ListItem>
                   )}

--- a/src/pages/ReportsPage/Widgets.tsx
+++ b/src/pages/ReportsPage/Widgets.tsx
@@ -153,7 +153,7 @@ export const Widgets: FC<ReportProps> = (props) => {
 
       <WidgetLayout title="Hours Worked">
         <Typography fontSize="2.5rem">
-          {totalHours?.toFixed(1) ?? "-"}
+          {totalHours?.toFixed(2) ?? "-"}
         </Typography>
       </WidgetLayout>
     </Stack>


### PR DESCRIPTION
added another decimal point to numbers in reports,
created a function that queries for "Closed Tasks" (cancelled or delivered) only when typing to remove clutter when scrolling through open tasks
when a closed task is selected a modal will pop up asking to reactivate the task.
if Reactivate is selected it will set the task state back to active and set the assignee to the re-activator.
if no is selected, it will just put more time on the closed task.
the modal has a link to the tasks detail page for more information.