### PR TITLE
quick fix for task states

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -102,13 +102,19 @@ export interface Task {
 }
 
 export enum TaskState {
-    Cancelled = "Cancelled",
     Hold = "Hold",
+    Ready = "Ready",
     Active = "Active",
     PullRequest = "PullRequest",
     Testing = "Testing",
+    Review = "Review",
+    HigherReview = "HigherReview",
+    FinalReview = "FinalReview",
     Approved = "Approved",
+    PartialDelivery1 = "PartialDelivery1",
+    PartialDelivery2 = "PartialDelivery2",
     Delivered = "Delivered",
+    Cancelled = "Cancelled",
 }
 
 export interface TimeEntry {

--- a/src/pages/Dashboard/TaskStateActionButton.tsx
+++ b/src/pages/Dashboard/TaskStateActionButton.tsx
@@ -57,6 +57,30 @@ const actions: Record<
   [TaskState.Cancelled]: {
     back: null,
     next: null
+  },
+  [TaskState.Ready]: {
+    back: null,
+    next: null
+  },
+  [TaskState.Review]: {
+    back: null,
+    next: null
+  },
+  [TaskState.HigherReview]: {
+    back: null,
+    next: null
+  },
+  [TaskState.FinalReview]: {
+    back: null,
+    next: null
+  },
+  [TaskState.PartialDelivery1]: {
+    back: null,
+    next: null
+  },
+  [TaskState.PartialDelivery2]: {
+    back: null,
+    next: null
   }
 }
 

--- a/src/pages/ProjectBoard/ProjectBoard.tsx
+++ b/src/pages/ProjectBoard/ProjectBoard.tsx
@@ -153,7 +153,13 @@ export const ProjectBoard: FC = () => {
       [TaskState.Hold]: [],
       [TaskState.Testing]: [],
       [TaskState.Approved]: [], // Unused
-      [TaskState.Cancelled]: [] // Unused
+      [TaskState.Cancelled]: [], // Unused
+      [TaskState.Ready]: [],
+      [TaskState.Review]: [],
+      [TaskState.HigherReview]: [],
+      [TaskState.FinalReview]: [],
+      [TaskState.PartialDelivery1]: [],
+      [TaskState.PartialDelivery2]: []
     }
 
     if ("tasks" in state) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -43,7 +43,13 @@ const taskStateOrder: Record<TaskState, number> = {
   [TaskState.Testing]: 2,
   [TaskState.Approved]: 3,
   [TaskState.Delivered]: 4,
-  [TaskState.Cancelled]: 5
+  [TaskState.Cancelled]: 5,
+  [TaskState.Ready]: 0,
+  [TaskState.Review]: 0,
+  [TaskState.HigherReview]: 0,
+  [TaskState.FinalReview]: 0,
+  [TaskState.PartialDelivery1]: 0,
+  [TaskState.PartialDelivery2]: 0
 }
 
 export function compareTasksByState(a: Task, b: Task): number {
@@ -158,7 +164,13 @@ export const taskStateLabels: Record<TaskState, string> = {
   [TaskState.PullRequest]: "Pull Request",
   [TaskState.Testing]: "Testing",
   [TaskState.Approved]: "Customer Review",
-  [TaskState.Delivered]: "Delivered"
+  [TaskState.Delivered]: "Delivered",
+  [TaskState.Ready]: "Ready",
+  [TaskState.Review]: "Review",
+  [TaskState.HigherReview]: "Higher Review",
+  [TaskState.FinalReview]: "Final Review",
+  [TaskState.PartialDelivery1]: "Partial Delivery 1",
+  [TaskState.PartialDelivery2]: "Partial Delivery 2"
 }
 
 export function getNameInitials(name: string): string {


### PR DESCRIPTION
A bunch of task states were added and it was making the old time tracker explode. Here is a quick fix to get it up and running again.